### PR TITLE
Refactor Toast into global HOC

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import CreateApplicationContainer from './containers/createApplication';
 import withNavbar from './hoc/withNavbar';
 import withThemeProvider from './hoc/withThemeProvider';
 import withHackerRedirect from './hoc/withHackerRedirect';
+import withToast from 'src/hoc/withToast';
 import { UserType, IAccount, IHacker } from './config/userTypes';
 import HackerStatus from './config/hackerStatus';
 import EditApplicationContainer from './containers/editApplication';
@@ -70,4 +71,4 @@ class App extends React.Component {
   }
 }
 
-export default withThemeProvider(App);
+export default withThemeProvider(withToast(App));

--- a/src/components/applicationComponent.tsx
+++ b/src/components/applicationComponent.tsx
@@ -34,7 +34,6 @@ import FileUploadComponent from 'src/components/fileUploadComponent';
 import StylizedSelectFormikComponent from 'src/components/StylizedSelectFormikComponent';
 import ValidationErrorGenerator from 'src/components/ValidationErrorGenerator';
 
-import WithToasterContainer from 'src/hoc/withToaster';
 import { Redirect } from 'react-router';
 import FrontendRoute from 'src/config/FrontendRoute';
 
@@ -415,7 +414,7 @@ class ManageApplicationContainer extends React.Component<IManageApplicationProps
                         { label: Skills.HTML, value: Skills.HTML },
                         { label: Skills.iOS, value: Skills.iOS },
                         { label: Skills.Java, value: Skills.Java },
-                        { label: Skills.Javascrips, value: Skills.Javascrips },
+                        { label: Skills.Javascript, value: Skills.Javascript },
                         { label: Skills.MachineLearning, value: Skills.MachineLearning },
                         { label: Skills.MobileApps, value: Skills.MobileApps },
                         { label: Skills.MongoDB, value: Skills.MongoDB },
@@ -621,4 +620,4 @@ class ManageApplicationContainer extends React.Component<IManageApplicationProps
     }
 
 }
-export default WithToasterContainer(ManageApplicationContainer);
+export default ManageApplicationContainer;

--- a/src/components/skillsComponent.tsx
+++ b/src/components/skillsComponent.tsx
@@ -32,7 +32,7 @@ const SkillsComponent: React.StatelessComponent<ISkillsComponentProps & FieldPro
         { label: Skills.HTML, value: Skills.HTML },
         { label: Skills.iOS, value: Skills.iOS },
         { label: Skills.Java, value: Skills.Java },
-        { label: Skills.Javascrips, value: Skills.Javascrips },
+        { label: Skills.Javascript, value: Skills.Javascript },
         { label: Skills.MachineLearning, value: Skills.MachineLearning },
         { label: Skills.MobileApps, value: Skills.MobileApps },
         { label: Skills.MongoDB, value: Skills.MongoDB },

--- a/src/containers/confirmEmail.tsx
+++ b/src/containers/confirmEmail.tsx
@@ -10,7 +10,6 @@ import MaxWidthBox from 'src/shared/MaxWidthBox';
 import { AxiosResponse } from 'axios';
 import APIResponse from 'src/api/APIResponse';
 import ValidationErrorGenerator from 'src/components/ValidationErrorGenerator';
-import WithToasterContainer from 'src/hoc/withToaster';
 import { RESEND_CONF_EMAIL, EMAIL_SENT } from 'src/config/constants';
 
 interface IConfirmationEmailSentState {
@@ -75,4 +74,4 @@ class ConfirmationEmailSentComponent extends React.Component<{}, IConfirmationEm
     }
 }
 
-export default WithToasterContainer(ConfirmationEmailSentComponent);
+export default ConfirmationEmailSentComponent;

--- a/src/containers/dashboard.tsx
+++ b/src/containers/dashboard.tsx
@@ -17,7 +17,6 @@ import hacker from 'src/api/hacker';
 import H1 from 'src/shared/H1';
 import FrontendRoute from 'src/config/FrontendRoute';
 import { isConfirmed } from 'src/util/UserInfoHelperFunctions';
-import WithToasterContainer from 'src/hoc/withToaster';
 import { toast } from 'react-toastify';
 import auth from 'src/api/auth';
 import APIResponse from 'src/api/APIResponse';
@@ -127,4 +126,4 @@ class DashboardContainer extends React.Component<{}, IDashboardState> {
         });
     }
 }
-export default WithToasterContainer(DashboardContainer);
+export default DashboardContainer;

--- a/src/containers/forgotPassword.tsx
+++ b/src/containers/forgotPassword.tsx
@@ -14,7 +14,6 @@ import MaxWidthBox from 'src/shared/MaxWidthBox';
 import PasswordResetEmailConfirmationContainer from 'src/containers/passwordResetEmailConfirmation';
 import ValidationErrorGenerator from 'src/components/ValidationErrorGenerator';
 import APIResponse from 'src/api/APIResponse';
-import WithToasterContainer from 'src/hoc/withToaster';
 
 export interface IForgotState {
     email: string;
@@ -128,4 +127,4 @@ class ForgotPasswordContainer extends React.Component<RouteComponentProps, IForg
     }
 }
 
-export default WithToasterContainer(withRouter<RouteComponentProps>(ForgotPasswordContainer));
+export default withRouter<RouteComponentProps>(ForgotPasswordContainer);

--- a/src/containers/login.tsx
+++ b/src/containers/login.tsx
@@ -16,8 +16,6 @@ import ForgotPasswordLinkComponent from 'src/components/forgotPasswordLinkCompon
 import BackgroundLandscape from 'src/assets/images/backgroundLandscape.svg';
 import BackgroundImage from 'src/shared/BackgroundImage';
 import MediaQuery from 'react-responsive';
-// import Container from 'src/shared/Container';
-import WithToasterContainer from 'src/hoc/withToaster';
 import ValidationErrorGenerator from 'src/components/ValidationErrorGenerator';
 import APIResponse from 'src/api/APIResponse';
 import auth from 'src/api/auth';
@@ -171,4 +169,4 @@ class LoginContainer extends React.Component<RouteComponentProps, ILoginState>{
         }
     }
 }
-export default WithToasterContainer(withRouter<RouteComponentProps>(LoginContainer));
+export default withRouter<RouteComponentProps>(LoginContainer);

--- a/src/containers/manageAccount.tsx
+++ b/src/containers/manageAccount.tsx
@@ -18,7 +18,6 @@ import Auth from 'src/api/auth';
 import MaxWidthBox from 'src/shared/MaxWidthBox';
 import Paragraph from 'src/shared/Paragraph';
 import ValidationErrorGenerator from 'src/components/ValidationErrorGenerator';
-import WithToasterContainer from 'src/hoc/withToaster';
 import { UserType, IAccount } from 'src/config/userTypes';
 import { Redirect } from 'react-router';
 import FrontendRoute from 'src/config/FrontendRoute';
@@ -288,4 +287,4 @@ class ManageAccountContainer extends React.Component<IManageAccountContainerProp
     }
 }
 
-export default WithToasterContainer(ManageAccountContainer);
+export default ManageAccountContainer;

--- a/src/containers/resetPassword.tsx
+++ b/src/containers/resetPassword.tsx
@@ -8,7 +8,6 @@ import H1 from 'src/shared/H1';
 import Button from 'src/shared/Button';
 import { Box, Flex } from '@rebass/grid';
 import MaxWidthBox from 'src/shared/MaxWidthBox';
-import WithToasterContainer from 'src/hoc/withToaster';
 import ValidationErrorGenerator from 'src/components/ValidationErrorGenerator';
 import APIResponse from 'src/api/APIResponse';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -116,4 +115,4 @@ class ResetPasswordContainer extends React.Component<RouteComponentProps, IReset
     }
 }
 
-export default withRouter<RouteComponentProps>(WithToasterContainer(ResetPasswordContainer));
+export default withRouter<RouteComponentProps>(ResetPasswordContainer);

--- a/src/hoc/withToast.tsx
+++ b/src/hoc/withToast.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { ToastContainer } from 'react-toastify';
-import { Box } from '@rebass/grid';
 
-const WithToasterContainer = <P extends {}>(Component: React.ComponentType<P>) =>
+const withToast = <P extends {}>(Component: React.ComponentType<P>) =>
     class extends React.Component<P> {
         constructor(props: any) {
             super(props);
@@ -10,14 +9,14 @@ const WithToasterContainer = <P extends {}>(Component: React.ComponentType<P>) =
 
         public render() {
             return (
-                <Box mt={'50px'}>
+                <div>
                     <Component {...this.props} />,
                     <ToastContainer
                         toastClassName='toast-notification'
                     />
-                </Box>
+                </div>
             )
         }
     }
 
-export default WithToasterContainer;
+export default withToast;


### PR DESCRIPTION
Closes #164. Should make code cleaner. Also has a cool little feature where we can now persist notifications across routes:

### Demo

In here, I added a `toast.success('TOASTY!')` in the `onClick` event in `dashboard.tsx`. The notification appears in the Edit Application page!

![screencast 2018-12-09 23-12-38](https://user-images.githubusercontent.com/16010076/49710559-43aab900-fc08-11e8-9e34-3c3d9ff8e9e4.gif)

### Reviewing

Please test for regression in any routes where we use Toast: Login, Create Account, Forgot Password, Dashboard, etc.