### PR TITLE
Fix Yup Validation

### DIFF
--- a/src/components/applicationComponent.tsx
+++ b/src/components/applicationComponent.tsx
@@ -222,12 +222,12 @@ class ManageApplicationContainer extends React.Component<
         .test(
           'length',
           'At most 2000 characters',
-          (value) => value.length < 2000
+          (value) => value && value.length < 2000
         ),
       comments: Yup.string().test(
         'length',
         'At most 500 characters',
-        (value) => value.length < 500
+        (value) => !value || value.length < 500
       ),
     });
   }


### PR DESCRIPTION
Fixes #238.

Prior to this, you would get an uncaught exception if you didn't type anything into the longform questions since their validation functions checked for `value.length`. I just added a guard to `value` to make sure it existed before proceeding to check its character length.