### PR TITLE
Remove left margin to align styled select with other inputs

### DIFF
--- a/src/shared/Form/StyledSelect.tsx
+++ b/src/shared/Form/StyledSelect.tsx
@@ -20,6 +20,10 @@ export const StyledSelect = styled(Select)`
       color: ${(props) => props.theme.colors.white};
     }
   }
+
+  .react-select__value-container {
+    padding-left: 0;
+  }
 `;
 
 export default StyledSelect;


### PR DESCRIPTION
Small fix. Realized that we forgot to copy a style over from one CSS component to another.
Before:
<img width="594" alt="image" src="https://user-images.githubusercontent.com/16010076/50407567-70ce9e00-07a8-11e9-8dde-b5714c288109.png">

After:
<img width="575" alt="image" src="https://user-images.githubusercontent.com/16010076/50407564-614f5500-07a8-11e9-94e9-b10b98f97879.png">
