### PR TITLE
Feature/search: place search query in URL

### DIFF
--- a/src/Search/Filters.tsx
+++ b/src/Search/Filters.tsx
@@ -63,7 +63,6 @@ class FilterComponent extends React.Component<IFilterProps, {}> {
         initFilters
       ),
     };
-    console.log(initVals);
     return initVals;
   }
 

--- a/src/Search/Filters.tsx
+++ b/src/Search/Filters.tsx
@@ -21,6 +21,7 @@ import { getOptionsFromEnum } from '../util';
 interface IFilterProps {
   initFilters: ISearchParameter[];
   onChange: (newFilters: ISearchParameter[]) => void;
+  onResetForm: () => void;
   loading: boolean;
 }
 
@@ -44,6 +45,7 @@ class FilterComponent extends React.Component<IFilterProps, {}> {
           Filters
         </H1>
         <Formik
+          enableReinitialize={true}
           initialValues={this.parseInitialValues(this.props.initFilters)}
           onSubmit={this.handleSubmit}
           render={this.renderFormik}
@@ -150,6 +152,7 @@ class FilterComponent extends React.Component<IFilterProps, {}> {
   private resetForm(fp: FormikProps<any>): () => void {
     return () => {
       fp.resetForm();
+      this.props.onResetForm();
     };
   }
   /**

--- a/src/Search/Filters.tsx
+++ b/src/Search/Filters.tsx
@@ -19,6 +19,7 @@ import theme from '../shared/Styles/theme';
 import { getOptionsFromEnum } from '../util';
 
 interface IFilterProps {
+  initFilters: ISearchParameter[];
   onChange: (newFilters: ISearchParameter[]) => void;
   loading: boolean;
 }
@@ -43,20 +44,29 @@ class FilterComponent extends React.Component<IFilterProps, {}> {
           Filters
         </H1>
         <Formik
-          initialValues={{
-            school: [],
-            gradYear: [],
-            degree: [],
-            status: [],
-            skills: [],
-            jobInterest: [],
-          }}
+          initialValues={this.parseInitialValues(this.props.initFilters)}
           onSubmit={this.handleSubmit}
           render={this.renderFormik}
         />
       </Box>
     );
   }
+  private parseInitialValues(initFilters: ISearchParameter[]) {
+    const initVals = {
+      school: this.searchParam2List('school', initFilters),
+      gradYear: this.searchParam2List('graduationYear', initFilters),
+      degree: this.searchParam2List('degree', initFilters),
+      status: this.searchParam2List('status', initFilters),
+      skills: this.searchParam2List('application.skills', initFilters),
+      jobInterest: this.searchParam2List(
+        'application.jobInterest',
+        initFilters
+      ),
+    };
+    console.log(initVals);
+    return initVals;
+  }
+
   private renderFormik(fp: FormikProps<any>) {
     return (
       <Form onSubmit={fp.handleSubmit}>
@@ -193,6 +203,22 @@ class FilterComponent extends React.Component<IFilterProps, {}> {
           },
         ]
       : [];
+  }
+  private searchParam2List(
+    param: string,
+    searchParamList: ISearchParameter[]
+  ): Array<string | number | boolean> {
+    let searches: Array<string | number | boolean> = [];
+    searchParamList.forEach((searchParam) => {
+      if (searchParam.param === param) {
+        if (Array.isArray(searchParam.value)) {
+          searches = searches.concat(searchParam.value);
+        } else {
+          searches.push(searchParam.value);
+        }
+      }
+    });
+    return searches;
   }
 }
 

--- a/src/Search/Search.tsx
+++ b/src/Search/Search.tsx
@@ -90,19 +90,23 @@ class SearchContainer extends React.Component<{}, ISearchState> {
     if (!search) {
       return [];
     }
-    const searchParam = JSON.parse(search);
-    if (!Array.isArray(searchParam)) {
+    try {
+      const searchParam = JSON.parse(search);
+      if (!Array.isArray(searchParam)) {
+        return [];
+      }
+      const isValidSearch =
+        searchParam
+          .map(
+            (value: any): boolean => {
+              return isValidSearchParameter(value);
+            }
+          )
+          .indexOf(false) === -1;
+      return isValidSearch ? searchParam : [];
+    } catch (e) {
       return [];
     }
-    const isValidSearch =
-      searchParam
-        .map(
-          (value: any): boolean => {
-            return isValidSearchParameter(value);
-          }
-        )
-        .indexOf(false) === -1;
-    return isValidSearch ? searchParam : [];
   }
 
   private downloadData(): void {
@@ -164,9 +168,12 @@ class SearchContainer extends React.Component<{}, ISearchState> {
     this.setState({
       query: newFilters,
     });
-    window.location.search = `q=${encodeURIComponent(
-      JSON.stringify(newFilters)
-    )}`;
+    const newSearch = `?q=${encodeURIComponent(JSON.stringify(newFilters))}`;
+    window.history.pushState(
+      null,
+      '',
+      window.location.href.split('?')[0] + newSearch
+    );
     this.triggerSearch();
   }
 }

--- a/src/Search/Search.tsx
+++ b/src/Search/Search.tsx
@@ -42,6 +42,7 @@ class SearchContainer extends React.Component<{}, ISearchState> {
     this.onFilterChange = this.onFilterChange.bind(this);
     this.triggerSearch = this.triggerSearch.bind(this);
     this.downloadData = this.downloadData.bind(this);
+    this.onResetForm = this.onResetForm.bind(this);
   }
   public render() {
     return (
@@ -50,6 +51,7 @@ class SearchContainer extends React.Component<{}, ISearchState> {
           <FilterComponent
             initFilters={this.state.query}
             onChange={this.onFilterChange}
+            onResetForm={this.onResetForm}
             loading={this.state.loading}
           />
         </Box>
@@ -164,17 +166,26 @@ class SearchContainer extends React.Component<{}, ISearchState> {
       this.setState({ loading: false });
     }
   }
+  private onResetForm() {
+    this.setState({ query: [] });
+    this.updateQueryURL([]);
+  }
+
   private onFilterChange(newFilters: ISearchParameter[]) {
     this.setState({
       query: newFilters,
     });
+    this.updateQueryURL(newFilters);
+    this.triggerSearch();
+  }
+
+  private updateQueryURL(newFilters: ISearchParameter[]) {
     const newSearch = `?q=${encodeURIComponent(JSON.stringify(newFilters))}`;
     window.history.pushState(
       null,
       '',
       window.location.href.split('?')[0] + newSearch
     );
-    this.triggerSearch();
   }
 }
 

--- a/src/Search/Search.tsx
+++ b/src/Search/Search.tsx
@@ -87,7 +87,6 @@ class SearchContainer extends React.Component<{}, ISearchState> {
   }
   private getSearchFromQuery(): ISearchParameter[] {
     const search = getValueFromQuery('q');
-    console.log(search);
     if (!search) {
       return [];
     }
@@ -165,6 +164,9 @@ class SearchContainer extends React.Component<{}, ISearchState> {
     this.setState({
       query: newFilters,
     });
+    window.location.search = `q=${encodeURIComponent(
+      JSON.stringify(newFilters)
+    )}`;
     this.triggerSearch();
   }
 }

--- a/src/Search/Search.tsx
+++ b/src/Search/Search.tsx
@@ -181,7 +181,7 @@ class SearchContainer extends React.Component<{}, ISearchState> {
 
   private updateQueryURL(newFilters: ISearchParameter[]) {
     const newSearch = `?q=${encodeURIComponent(JSON.stringify(newFilters))}`;
-    window.history.pushState(
+    window.history.replaceState(
       null,
       '',
       window.location.href.split('?')[0] + newSearch

--- a/src/config/searchParameter.ts
+++ b/src/config/searchParameter.ts
@@ -22,3 +22,14 @@ export interface ISearchParameter {
   operation: StringOperations | NumberOperations | BooleanOperations;
   value: string | boolean | number | string[] | number[];
 }
+
+export function isValidSearchParameter(parameter: any) {
+  if (!parameter) {
+    return false;
+  }
+  const { param, operation, value } = parameter;
+  if (param && typeof param === 'string' && operation && value) {
+    return true;
+  }
+  return false;
+}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,3 +1,5 @@
+import * as QueryString from 'query-string';
+
 function padStart(padNum: number, padValue: string, value: string): string {
   if (value.length < padNum) {
     const pad = String(padValue).repeat(padNum - value.length);
@@ -43,4 +45,16 @@ function date2input(date: string) {
   return `${month}${day}${year}`;
 }
 
-export { padStart, getNestedAttr, getOptionsFromEnum, input2date, date2input };
+function getValueFromQuery(key: string): string | undefined {
+  const queries: any = QueryString.parse(location.search);
+  return queries[key];
+}
+
+export {
+  padStart,
+  getNestedAttr,
+  getOptionsFromEnum,
+  getValueFromQuery,
+  input2date,
+  date2input,
+};


### PR DESCRIPTION
## Description:

Add search query into url so that users can copy-paste queries to each other, and also other parts of the site can trigger queries. 

## Fixes #297

## Features:

- Providing a search in the URL (such as http://localhost:1337/admin/search?q=[%7B%22param%22:%22accountId.gender%22,%22operation%22:%22in%22,%22value%22:[%22Male%22]%7D] ) triggers a search on load
- The filters are populated with the proper values that reflect the url
- When the filters change & submitted, the url is changed as well
