### PR TITLE
Clear hacker cache when user joins team

### DIFF
--- a/src/Team/Main.tsx
+++ b/src/Team/Main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { Hacker } from '../api';
 import Team from '../api/team';

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -24,6 +24,7 @@ class TeamAPI {
    * @param name the team name
    */
   public join(name: string): AxiosPromise<APIResponse<{}>> {
+    LocalCache.remove(CACHE_HACKER_KEY);
     return API.getEndpoint(APIRoute.TEAM_JOIN).patch({ id: '' }, { name });
   }
   /**


### PR DESCRIPTION
When we do not clear cache, the team page does not rerender to show the team information.