### PR TITLE
Allow sponsors to save hackers

### DIFF
--- a/src/Search/Context.tsx
+++ b/src/Search/Context.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ISponsor } from '../config';
 
-const MyContext = React.createContext({} as ISponsor | undefined);
+const NomineeContext = React.createContext({} as ISponsor | undefined);
 
-export default MyContext;
+export default NomineeContext;

--- a/src/Search/Context.tsx
+++ b/src/Search/Context.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { ISponsor } from '../config';
+
+const MyContext = React.createContext({} as ISponsor | undefined);
+
+export default MyContext;

--- a/src/Search/HackerSelect.tsx
+++ b/src/Search/HackerSelect.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import { Checkbox } from '../shared/Form/';
+
+import { Sponsor } from '../api';
+import { ISponsor } from '../config';
+
+interface IProps {
+  hackerId: string;
+}
+
+interface IState {
+  isChecked: boolean;
+  isChanging: boolean;
+  sponsor?: ISponsor;
+}
+
+class HackerSelect extends React.Component<IProps, IState> {
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      isChecked: false,
+      isChanging: false,
+      sponsor: undefined,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+  public render() {
+    return (
+      <div>
+        <Checkbox checked={this.state.isChecked} onChange={this.handleChange} />
+      </div>
+    );
+  }
+
+  public async componentDidMount() {
+    const { hackerId } = this.props;
+
+    const response = await Sponsor.getSelf();
+    const sponsor = response.data.data;
+    const isChecked = sponsor.nominees.indexOf(hackerId) > -1;
+    this.setState({ sponsor, isChecked });
+  }
+
+  private async handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const isChecked = event.target.checked;
+    const { sponsor, isChanging } = this.state;
+    const { hackerId } = this.props;
+
+    if (!sponsor || isChanging) {
+      return;
+    }
+
+    if (isChecked) {
+      sponsor.nominees.push(hackerId);
+    } else {
+      sponsor.nominees = sponsor.nominees.filter((n) => n !== hackerId);
+    }
+
+    this.setState({ isChanging: true });
+    await Sponsor.update(sponsor);
+    this.setState({ isChanging: false });
+    this.setState({ isChecked });
+  }
+}
+
+export default HackerSelect;

--- a/src/Search/HackerSelect.tsx
+++ b/src/Search/HackerSelect.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-
-import { Checkbox } from '../shared/Form/';
-
 import { Sponsor } from '../api';
-import { ISponsor } from '../config';
+import { Checkbox } from '../shared/Form/';
+import MyContext from './Context';
 
 interface IProps {
   hackerId: string;
@@ -12,16 +10,16 @@ interface IProps {
 interface IState {
   isChecked: boolean;
   isChanging: boolean;
-  sponsor?: ISponsor;
 }
 
 class HackerSelect extends React.Component<IProps, IState> {
+  public static contextType = MyContext;
+
   constructor(props: IProps) {
     super(props);
     this.state = {
       isChecked: false,
       isChanging: false,
-      sponsor: undefined,
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -37,29 +35,29 @@ class HackerSelect extends React.Component<IProps, IState> {
   public async componentDidMount() {
     const { hackerId } = this.props;
 
-    const response = await Sponsor.getSelf();
-    const sponsor = response.data.data;
-    const isChecked = sponsor.nominees.indexOf(hackerId) > -1;
-    this.setState({ sponsor, isChecked });
+    const isChecked = this.context.nominees.indexOf(hackerId) > -1;
+    this.setState({ isChecked });
   }
 
   private async handleChange(event: React.ChangeEvent<HTMLInputElement>) {
     const isChecked = event.target.checked;
-    const { sponsor, isChanging } = this.state;
+    const { isChanging } = this.state;
     const { hackerId } = this.props;
 
-    if (!sponsor || isChanging) {
+    if (isChanging) {
       return;
     }
 
     if (isChecked) {
-      sponsor.nominees.push(hackerId);
+      this.context.nominees.push(hackerId);
     } else {
-      sponsor.nominees = sponsor.nominees.filter((n) => n !== hackerId);
+      this.context.nominees = this.context.nominees.filter(
+        (n: string) => n !== hackerId
+      );
     }
 
     this.setState({ isChanging: true });
-    await Sponsor.update(sponsor);
+    await Sponsor.update(this.context);
     this.setState({ isChanging: false });
     this.setState({ isChecked });
   }

--- a/src/Search/HackerSelect.tsx
+++ b/src/Search/HackerSelect.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Sponsor } from '../api';
 import { Checkbox } from '../shared/Form/';
-import MyContext from './Context';
+import NomineeContext from './Context';
 
 interface IProps {
   hackerId: string;
@@ -13,7 +13,7 @@ interface IState {
 }
 
 class HackerSelect extends React.Component<IProps, IState> {
-  public static contextType = MyContext;
+  public static contextType = NomineeContext;
 
   constructor(props: IProps) {
     super(props);

--- a/src/Search/ResultsTable.tsx
+++ b/src/Search/ResultsTable.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { IHacker, UserType } from '../config';
 import { StyledTable } from '../shared/Elements';
 import SingleHackerModal from '../SingleHacker/SingleHackerModal';
+import HackerSelect from './HackerSelect';
 
 interface IResultsTableProps {
   results: Array<{
@@ -15,11 +16,15 @@ interface IResultsTableProps {
 }
 
 const ResultsTable: React.StatelessComponent<IResultsTableProps> = (props) => {
-  const adminColumns = [
+  const volunteerColumns = [
     {
       Header: 'First Name',
       accessor: 'hacker.accountId.firstName',
     },
+  ];
+
+  const adminColumns = [
+    ...volunteerColumns,
     {
       Header: 'Last Name',
       accessor: 'hacker.accountId.lastName',
@@ -54,18 +59,32 @@ const ResultsTable: React.StatelessComponent<IResultsTableProps> = (props) => {
     },
   ];
 
-  const volunteerColumns = [
+  const sponsorColumns = [
+    ...adminColumns,
     {
-      Header: 'First Name',
-      accessor: 'hacker.accountId.firstName',
+      Header: 'Save',
+      Cell: ({ original }: any) => (
+        <HackerSelect hackerId={original.hacker.id} />
+      ),
     },
   ];
+
+  let columns;
+  switch (props.userType) {
+    case UserType.VOLUNTEER:
+      columns = volunteerColumns;
+      break;
+    case UserType.STAFF:
+      columns = adminColumns;
+      break;
+    default:
+      columns = sponsorColumns;
+      break;
+  }
   return (
     <StyledTable
       data={props.results}
-      columns={
-        props.userType === UserType.VOLUNTEER ? volunteerColumns : adminColumns
-      }
+      columns={columns}
       loading={props.loading}
       defaultPageSize={10}
     />

--- a/src/Search/Search.tsx
+++ b/src/Search/Search.tsx
@@ -289,8 +289,6 @@ class SearchContainer extends React.Component<{}, ISearchState> {
         !viewSaved ||
         (sponsor && sponsor.nominees.some((n) => n === hacker.id));
 
-      console.log(isSavedBySponsorIfToggled);
-
       return (foundAcct || foundHacker) && isSavedBySponsorIfToggled;
     });
   }

--- a/src/Search/Search.tsx
+++ b/src/Search/Search.tsx
@@ -63,14 +63,7 @@ class SearchContainer extends React.Component<{}, ISearchState> {
   }
 
   public render() {
-    const {
-      searchBar,
-      account,
-      query,
-      results,
-      loading,
-      viewSaved,
-    } = this.state;
+    const { searchBar, account, query, loading, viewSaved } = this.state;
     return (
       <Flex flexDirection={'column'}>
         <Helmet>
@@ -126,7 +119,7 @@ class SearchContainer extends React.Component<{}, ISearchState> {
             <Box width={5 / 6} m={2}>
               <NomineeContext.Provider value={this.state.sponsor}>
                 <ResultsTable
-                  results={this.filter(results, searchBar)}
+                  results={this.filter()}
                   loading={loading}
                   userType={account ? account.accountType : UserType.UNKNOWN}
                   filter={searchBar}
@@ -195,7 +188,7 @@ class SearchContainer extends React.Component<{}, ISearchState> {
       'needsBus',
     ];
     const csvData: string[] = [headers.join('\t')];
-    this.filter(this.state.results, this.state.searchBar).forEach((result) => {
+    this.filter().forEach((result) => {
       if (result.selected) {
         const row: string[] = [];
         headers.forEach((header) => {
@@ -264,26 +257,27 @@ class SearchContainer extends React.Component<{}, ISearchState> {
     );
   }
 
-  private filter(results: IResult[], search: string): IResult[] {
-    const { sponsor, viewSaved } = this.state;
+  private filter() {
+    const { sponsor, viewSaved, results, searchBar } = this.state;
 
     return results.filter(({ hacker }) => {
       const { accountId } = hacker;
+      const account = accountId as IAccount;
+
+      const fullName = `${account.firstName} ${account.lastName}`;
       const foundAcct =
-        typeof accountId !== 'string'
-          ? `${accountId.firstName} ${accountId.lastName}`.includes(search) ||
-            accountId.email.includes(search) ||
-            String(accountId.phoneNumber).includes(search) ||
-            accountId.shirtSize.includes(search) ||
-            (accountId._id && accountId._id.includes(search))
-          : false;
+        fullName.includes(searchBar) ||
+        account.email.includes(searchBar) ||
+        account.phoneNumber.toString().includes(searchBar) ||
+        account.shirtSize.includes(searchBar) ||
+        (account._id && account._id.includes(searchBar));
 
       const foundHacker =
-        hacker.id.includes(search) ||
-        hacker.major.includes(search) ||
-        hacker.school.includes(search) ||
-        hacker.status.includes(search) ||
-        String(hacker.graduationYear).includes(search);
+        hacker.id.includes(searchBar) ||
+        hacker.major.includes(searchBar) ||
+        hacker.school.includes(searchBar) ||
+        hacker.status.includes(searchBar) ||
+        hacker.graduationYear.toString().includes(searchBar);
 
       const isSavedBySponsorIfToggled =
         !viewSaved ||

--- a/src/Search/Search.tsx
+++ b/src/Search/Search.tsx
@@ -3,11 +3,12 @@ import fileDownload from 'js-file-download';
 import * as React from 'react';
 import Helmet from 'react-helmet';
 
-import { Account, Search } from '../api';
+import { Account, Search, Sponsor } from '../api';
 import {
   IAccount,
   IHacker,
   ISearchParameter,
+  ISponsor,
   isValidSearchParameter,
   UserType,
 } from '../config';
@@ -16,24 +17,30 @@ import { Input } from '../shared/Form';
 import ValidationErrorGenerator from '../shared/Form/validationErrorGenerator';
 import WithToasterContainer from '../shared/HOC/withToaster';
 import theme from '../shared/Styles/theme';
-import { getNestedAttr, getValueFromQuery } from '../util';
+import { getNestedAttr, getValueFromQuery, isSponsor } from '../util';
+
+import MyContext from './Context';
 import { FilterComponent } from './Filters';
 import { ResultsTable } from './ResultsTable';
+
+interface IResult {
+  /**
+   * For now, we aren't exposing 'selected' attribute. We set it default equal to true.
+   * This is used for batch operations for changing hacker data.
+   */
+  selected: boolean;
+  hacker: IHacker;
+}
 
 interface ISearchState {
   model: string;
   query: ISearchParameter[];
-  results: Array<{
-    /**
-     * For now, we aren't exposing 'selected' attribute. We set it default equal to true.
-     * This is used for batch operations for changing hacker data.
-     */
-    selected: boolean;
-    hacker: IHacker;
-  }>;
+  results: IResult[];
   searchBar: string;
   loading: boolean;
+  viewSaved: boolean;
   account?: IAccount;
+  sponsor?: ISponsor;
 }
 
 class SearchContainer extends React.Component<{}, ISearchState> {
@@ -45,7 +52,9 @@ class SearchContainer extends React.Component<{}, ISearchState> {
       results: [],
       searchBar: this.getSearchBarFromQuery(),
       loading: false,
+      viewSaved: false,
     };
+
     this.onFilterChange = this.onFilterChange.bind(this);
     this.triggerSearch = this.triggerSearch.bind(this);
     this.downloadData = this.downloadData.bind(this);
@@ -54,7 +63,14 @@ class SearchContainer extends React.Component<{}, ISearchState> {
   }
 
   public render() {
-    const { searchBar, account, query, results, loading } = this.state;
+    const {
+      searchBar,
+      account,
+      query,
+      results,
+      loading,
+      viewSaved,
+    } = this.state;
     return (
       <Flex flexDirection={'column'}>
         <Helmet>
@@ -86,6 +102,11 @@ class SearchContainer extends React.Component<{}, ISearchState> {
                   {account && account.accountType === UserType.STAFF && (
                     <Button>Update Status</Button>
                   )}
+                  {account && isSponsor(account) && (
+                    <Button onClick={this.toggleSaved}>
+                      View {viewSaved ? 'All' : 'Saved'}
+                    </Button>
+                  )}
                   <Button onClick={this.downloadData}>Export Hackers</Button>
                 </Box>
               </Flex>
@@ -103,12 +124,14 @@ class SearchContainer extends React.Component<{}, ISearchState> {
               />
             </Box>
             <Box width={5 / 6} m={2}>
-              <ResultsTable
-                results={this.filter(results, searchBar)}
-                loading={loading}
-                userType={account ? account.accountType : UserType.UNKNOWN}
-                filter={searchBar}
-              />
+              <MyContext.Provider value={this.state.sponsor}>
+                <ResultsTable
+                  results={this.filter(results, searchBar)}
+                  loading={loading}
+                  userType={account ? account.accountType : UserType.UNKNOWN}
+                  filter={searchBar}
+                />
+              </MyContext.Provider>
             </Box>
           </Flex>
         </Box>
@@ -118,6 +141,11 @@ class SearchContainer extends React.Component<{}, ISearchState> {
   public async componentDidMount() {
     const account = (await Account.getSelf()).data.data;
     this.setState({ account });
+
+    if (isSponsor(account)) {
+      const sponsor = (await Sponsor.getSelf()).data.data;
+      this.setState({ sponsor });
+    }
 
     if (this.state.query.length > 0 || this.state.searchBar.length > 0) {
       this.triggerSearch();
@@ -236,16 +264,9 @@ class SearchContainer extends React.Component<{}, ISearchState> {
     );
   }
 
-  private filter(
-    results: Array<{
-      selected: boolean;
-      hacker: IHacker;
-    }>,
-    search: string
-  ): Array<{
-    selected: boolean;
-    hacker: IHacker;
-  }> {
+  private filter(results: IResult[], search: string): IResult[] {
+    const { sponsor, viewSaved } = this.state;
+
     return results.filter(({ hacker }) => {
       const { accountId } = hacker;
       const foundAcct =
@@ -257,16 +278,29 @@ class SearchContainer extends React.Component<{}, ISearchState> {
             (accountId._id && accountId._id.includes(search))
           : false;
 
-      return (
-        foundAcct ||
+      const foundHacker =
         hacker.id.includes(search) ||
         hacker.major.includes(search) ||
         hacker.school.includes(search) ||
         hacker.status.includes(search) ||
-        String(hacker.graduationYear).includes(search)
-      );
+        String(hacker.graduationYear).includes(search);
+
+      const isSavedBySponsorIfToggled =
+        !viewSaved ||
+        (sponsor && sponsor.nominees.some((n) => n === hacker.id));
+
+      console.log(isSavedBySponsorIfToggled);
+
+      return (foundAcct || foundHacker) && isSavedBySponsorIfToggled;
     });
   }
+
+  private toggleSaved = () => {
+    const { sponsor, viewSaved } = this.state;
+    if (sponsor) {
+      this.setState({ viewSaved: !viewSaved });
+    }
+  };
 }
 
 export default WithToasterContainer(SearchContainer);

--- a/src/Search/Search.tsx
+++ b/src/Search/Search.tsx
@@ -19,7 +19,7 @@ import WithToasterContainer from '../shared/HOC/withToaster';
 import theme from '../shared/Styles/theme';
 import { getNestedAttr, getValueFromQuery, isSponsor } from '../util';
 
-import MyContext from './Context';
+import NomineeContext from './Context';
 import { FilterComponent } from './Filters';
 import { ResultsTable } from './ResultsTable';
 
@@ -124,14 +124,14 @@ class SearchContainer extends React.Component<{}, ISearchState> {
               />
             </Box>
             <Box width={5 / 6} m={2}>
-              <MyContext.Provider value={this.state.sponsor}>
+              <NomineeContext.Provider value={this.state.sponsor}>
                 <ResultsTable
                   results={this.filter(results, searchBar)}
                   loading={loading}
                   userType={account ? account.accountType : UserType.UNKNOWN}
                   filter={searchBar}
                 />
-              </MyContext.Provider>
+              </NomineeContext.Provider>
             </Box>
           </Flex>
         </Box>

--- a/src/api/sponsor.ts
+++ b/src/api/sponsor.ts
@@ -1,8 +1,9 @@
 import { AxiosPromise, AxiosResponse } from 'axios';
-import { APIRoute, ISponsor, CACHE_SPONSOR_KEY } from '../config';
-import API from './api';
 import { APIResponse } from '.';
+import { APIRoute, CACHE_SPONSOR_KEY, ISponsor } from '../config';
 import LocalCache from '../util/LocalCache';
+import API from './api';
+
 class SponsorAPI {
   constructor() {
     API.createEntity(APIRoute.SPONSOR);


### PR DESCRIPTION
* Adds a new column in the results table for sponsors to save applicants.
* Can filter by saved applicants with a button to the right of the search bar.

Some notes:
* See [docs on Context API](https://reactjs.org/docs/context.html).
* Can't save/un-save in Single Hacker View. This capability might be nice, but we should discuss how to implement it.
* Un-saving when in "View Saved" mode does not immediately remove the unsaved hacker from the results table.
* I refactored some code here and there, most notably `this.filter()` in `Search.tsx`.